### PR TITLE
Replaced stdout prints with python logging module calls

### DIFF
--- a/pykeyboard/__init__.py
+++ b/pykeyboard/__init__.py
@@ -23,6 +23,9 @@ http://github.com/SavinaRoja/PyUserInput
 """
 
 import sys
+import logging
+
+logger = logging.getLogger("PyUserInput")
 
 if sys.platform.startswith('java'):
     from .java_ import PyKeyboard

--- a/pykeyboard/mac.py
+++ b/pykeyboard/mac.py
@@ -16,6 +16,8 @@
 import time
 import Quartz
 from AppKit import NSSystemDefined, NSEvent
+
+from . import logger
 from .base import PyKeyboardMeta, PyKeyboardEventMeta
 
 # Taken from events.h
@@ -229,22 +231,22 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
         self.state = False
 
     def _diagnostic(self,key,event):
-        print('\n---Keyboard Event Diagnostic---')
-        #print('MessageName:', event.MessageName)
-        #print('Message:', event.Message)
-        #print('Time:', event.Time)
-        #print('Window:', event.Window)
-        #print('WindowName:', event.WindowName)
-        #print('Ascii:', event.Ascii, ',', chr(event.Ascii))
-        print('Key:',key_code_translate_table[key])
-        print('Key Code:',key)
-        #print('KeyID:', event.KeyID)
-        #print('ScanCode:', event.ScanCode)
-        #print('Extended:', event.Extended)
-        #print('Injected:', event.Injected)
-        #print('Alt', event.Alt)
-        #print('Transition', event.Transition)
-        print('---')
+        logger.info('\n---Keyboard Event Diagnostic---')
+        logger.debug('MessageName:', event.MessageName)
+        logger.debug('Message:', event.Message)
+        logger.debug('Time:', event.Time)
+        logger.debug('Window:', event.Window)
+        logger.debug('WindowName:', event.WindowName)
+        logger.debug('Ascii:', event.Ascii, ',', chr(event.Ascii))
+        logger.info('Key:',key_code_translate_table[key])
+        logger.info('Key Code:',key)
+        logger.debug('KeyID:', event.KeyID)
+        logger.debug('ScanCode:', event.ScanCode)
+        logger.debug('Extended:', event.Extended)
+        logger.debug('Injected:', event.Injected)
+        logger.debug('Alt', event.Alt)
+        logger.debug('Transition', event.Transition)
+        logger.info('---')
 
     def handler(self, proxy, type, event, refcon):
         key = Quartz.CGEventGetIntegerValueField(event, Quartz.kCGKeyboardEventKeycode)

--- a/pykeyboard/windows.py
+++ b/pykeyboard/windows.py
@@ -18,6 +18,7 @@ import win32api
 from win32con import *
 import pythoncom
 
+from . import logger
 from .base import PyKeyboardMeta, PyKeyboardEventMeta
 
 import time
@@ -285,21 +286,21 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
         and easily available. It will print out information regarding the event
         instead of passing information along to self.tap()
         """
-        print('\n---Keyboard Event Diagnostic---')
-        print('MessageName:', event.MessageName)
-        print('Message:', event.Message)
-        print('Time:', event.Time)
-        print('Window:', event.Window)
-        print('WindowName:', event.WindowName)
-        print('Ascii:', event.Ascii, ',', chr(event.Ascii))
-        print('Key:', event.Key)
-        print('KeyID:', event.KeyID)
-        print('ScanCode:', event.ScanCode)
-        print('Extended:', event.Extended)
-        print('Injected:', event.Injected)
-        print('Alt', event.Alt)
-        print('Transition', event.Transition)
-        print('---')
+        logger.info('\n---Keyboard Event Diagnostic---')
+        logger.info('MessageName:', event.MessageName)
+        logger.info('Message:', event.Message)
+        logger.info('Time:', event.Time)
+        logger.info('Window:', event.Window)
+        logger.info('WindowName:', event.WindowName)
+        logger.info('Ascii:', event.Ascii, ',', chr(event.Ascii))
+        logger.info('Key:', event.Key)
+        logger.info('KeyID:', event.KeyID)
+        logger.info('ScanCode:', event.ScanCode)
+        logger.info('Extended:', event.Extended)
+        logger.info('Injected:', event.Injected)
+        logger.info('Alt', event.Alt)
+        logger.info('Transition', event.Transition)
+        logger.info('---')
 
     def escape(self, event):
         return event.KeyID == VK_ESCAPE

--- a/pykeyboard/x11.py
+++ b/pykeyboard/x11.py
@@ -21,6 +21,7 @@ from Xlib.protocol import rq
 import Xlib.XK
 import Xlib.keysymdef.xkb
 
+from . import logger
 from .base import PyKeyboardMeta, PyKeyboardEventMeta
 
 import time
@@ -234,9 +235,9 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
         #self.configure_keys()
 
         #Direct access to the display's keycode-to-keysym array
-        #print('Keycode to Keysym map')
-        #for i in range(len(self.display._keymap_codes)):
-        #    print('{0}: {1}'.format(i, self.display._keymap_codes[i]))
+        logger.debug('Keycode to Keysym map')
+        for i in range(len(self.display._keymap_codes)):
+            logger.debug('{0}: {1}'.format(i, self.display._keymap_codes[i]))
 
         PyKeyboardEventMeta.__init__(self, capture)
 
@@ -341,8 +342,8 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
         try:
             char = self.keysym_to_string[keysym]
         except KeyError:
-            print('Unable to determine character.')
-            print('Keycode: {0} KeySym {1}'.format(keycode, keysym))
+            logger.info('Unable to determine character.')
+            logger.info('Keycode: {0} KeySym {1}'.format(keycode, keysym))
             return None
         else:
             return char
@@ -404,7 +405,7 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
             self.lock_meaning = 'Caps_Lock'
         else:
             self.lock_meaning = None
-        #print('Lock is bound to {0}'.format(self.lock_meaning))
+        logger.debug('Lock is bound to {0}'.format(self.lock_meaning))
 
         #Need to find out which Mod# to use for Alt, Num_Lock, Super, and
         #Mode_switch


### PR DESCRIPTION
The log printing straight to stdout is kind of annoying since you cannot silence it in any way. Here i replaced all print calls to calls with the built-in standard python logging module so if anyone wants to silence the output from PyUserInput from their stdout they can.

This is so the https://github.com/ActivityWatch/aw-watcher-afk project can silence these messages

```
Unable to determine character.
Keycode: 65 KeySym 0
```

Output without silencing will now look like this instead

```
2017-07-14 20:21:02,579 [INFO ]: Unable to determine character.  (PyUserInput:345)
2017-07-14 20:21:02,580 [INFO ]: Keycode: 36 KeySym 0  (PyUserInput:346)
```

https://github.com/ActivityWatch/activitywatch/issues/87