### PR TITLE
Loggers now uses __name__ instead of hardcoded "PyUserInput"

### DIFF
--- a/pykeyboard/__init__.py
+++ b/pykeyboard/__init__.py
@@ -23,9 +23,6 @@ http://github.com/SavinaRoja/PyUserInput
 """
 
 import sys
-import logging
-
-logger = logging.getLogger("PyUserInput")
 
 if sys.platform.startswith('java'):
     from .java_ import PyKeyboard

--- a/pykeyboard/mac.py
+++ b/pykeyboard/mac.py
@@ -17,8 +17,10 @@ import time
 import Quartz
 from AppKit import NSSystemDefined, NSEvent
 
-from . import logger
 from .base import PyKeyboardMeta, PyKeyboardEventMeta
+
+import logging
+logger = logging.getLogger(__name__)
 
 # Taken from events.h
 # /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h

--- a/pykeyboard/windows.py
+++ b/pykeyboard/windows.py
@@ -18,11 +18,12 @@ import win32api
 from win32con import *
 import pythoncom
 
-from . import logger
 from .base import PyKeyboardMeta, PyKeyboardEventMeta
 
 import time
 
+import logging
+logger = logging.getLogger(__name__)
 
 class SupportError(Exception):
     """For keys not supported on this system"""

--- a/pykeyboard/x11.py
+++ b/pykeyboard/x11.py
@@ -21,8 +21,10 @@ from Xlib.protocol import rq
 import Xlib.XK
 import Xlib.keysymdef.xkb
 
-from . import logger
 from .base import PyKeyboardMeta, PyKeyboardEventMeta
+
+import logging
+logger = logging.getLogger(__name__)
 
 import time
 import string


### PR DESCRIPTION
Sorry, my previous PR wasn't completely thought-through. Here's an improvement.

By using \_\_name\_\_ instead of hardcoded "PyUserInput" is how the standard python design pattern is, which creates a logger hierarchy such as "pykeyboard.x11" instead of just "PyUserInput"

This also makes it possible to see in the logs where the log message was created, changing the log messages from this format

```
2017-07-14 20:21:02,579 [INFO ]: Unable to determine character.  (PyUserInput:345)
2017-07-14 20:21:02,580 [INFO ]: Keycode: 36 KeySym 0  (PyUserInput:346)
```

to this

```
2017-07-16 12:50:09,741 [INFO ]: Unable to determine character.  (pykeyboard.x11:347)
2017-07-16 12:50:09,741 [INFO ]: Keycode: 36 KeySym 0  (pykeyboard.x11:348)
```

So you can see that it is printed on line 347/348 in pykeyboard.x11