### PR TITLE
Fix long int overflow on Windows

### DIFF
--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -21,8 +21,8 @@ import pythoncom
 from time import sleep
 
 class POINT(Structure):
-    _fields_ = [("x", c_ulong),
-                ("y", c_ulong)]
+    _fields_ = [("x", c_long),
+                ("y", c_long)]
 
 class PyMouse(PyMouseMeta):
     """MOUSEEVENTF_(button and action) constants


### PR DESCRIPTION
Hi,

I have two screens connected to my computer and when the mouse is inside the second screen and I run:

```
m = PyMouse()
m.click(*m.position())
```

I get this error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files\Python36\lib\site-packages\pymouse\base.py", line 56, in click
    self.press(x, y, button)
  File "C:\Program Files\Python36\lib\site-packages\pymouse\windows.py", line 34, in press
    win32api.mouse_event(buttonAction, x, y)
OverflowError: Python int too large to convert to C long
```

The cause are the coordinates returned by `m.position()` that are unsigned long while `click()` expects singed long values. 

I fixed this by making `position()` return a signed long tuple.