### PR TITLE
Fix freezing after calling .stop() on PyMouseEvent

### DIFF
--- a/pymouse/x11.py
+++ b/pymouse/x11.py
@@ -198,9 +198,9 @@ class PyMouseEvent(PyMouseEventMeta):
         with display_manager(self.display) as d:
             d.ungrab_pointer(X.CurrentTime)
             d.record_disable_context(self.ctx)
-        with display_manager(self.display2) as d:
-            d.ungrab_pointer(X.CurrentTime)
-            d.record_disable_context(self.ctx)
+
+        self.display2.ungrab_pointer(X.CurrentTime)
+        self.display2.record_disable_context(self.ctx)
 
     def handler(self, reply):
         data = reply.data


### PR DESCRIPTION
I removed the context manager from `PyMouseEvent.display2`, to prevent a second call of `Display.sync()`. This second call caused the function to block indefinitely.

This should fix #55 .